### PR TITLE
Changes on how /auth/register/ works. Small modifications to user model

### DIFF
--- a/auth/serializers.py
+++ b/auth/serializers.py
@@ -4,28 +4,34 @@ from rest_framework import serializers
 
 User = get_user_model()
 
-class RegisterSerializer(serializers.ModelSerializer):
-    password = serializers.CharField(
-        write_only=True, required=True, validators=[validate_password])
-    password2 = serializers.CharField(write_only=True, required=True)
 
+class RegisterSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('username', 'password', 'password2')
+        fields = (
+            "id",
+            "first_name",
+            "last_name",
+            "email",
+            "phone_number",
+            "password",
+        )
 
     def validate(self, attrs):
-        if attrs['password'] != attrs['password2']:
-            raise serializers.ValidationError(
-                {"password": "Password fields didn't match."})
+        email = attrs["email"]
+        if User.objects.filter(email=email).exists():
+            raise serializers.ValidationError({"message": "El usuario ya existe"})
 
         return attrs
 
     def create(self, validated_data):
         user = User.objects.create(
-            username=validated_data['username']
+            username=validated_data["email"],
+            email=validated_data["email"],
+            first_name=validated_data["first_name"],
+            last_name=validated_data["last_name"],
+            phone_number=validated_data["phone_number"],
         )
-
-        user.set_password(validated_data['password'])
+        user.set_password(validated_data["password"])
         user.save()
-
         return user

--- a/auth/views.py
+++ b/auth/views.py
@@ -1,13 +1,30 @@
 from django.contrib.auth import get_user_model
 from django.shortcuts import render
-from rest_framework import generics
+from rest_framework import viewsets, status
+from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
+from rest_framework_simplejwt.tokens import RefreshToken, AccessToken
 from auth.serializers import RegisterSerializer
 
 User = get_user_model()
 
+
 # Create your views here.
-class RegisterView(generics.CreateAPIView):
-    queryset = User.objects.all()
-    permission_classes = (AllowAny,)
-    serializer_class = RegisterSerializer
+class RegisterView(viewsets.ViewSet):
+    def create(self, request):
+        serializer = RegisterSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+
+        refresh = RefreshToken.for_user(user)
+        access = AccessToken.for_user(user)
+        refresh_token = str(refresh)
+        access_token = str(access)
+        return Response(
+            {
+                "message": "User registered successfully!",
+                "access": access_token,
+                "refresh": refresh_token,
+            },
+            status=status.HTTP_201_CREATED,
+        )

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,7 @@ services:
     command: >
       sh -c "python manage.py makemigrations && 
              python manage.py migrate &&
-             python manage.py runserver"
+             python manage.py runserver 0.0.0.0:8000"
     ports:
       - 8000:8000
     develop:

--- a/pidecola_back/settings.py
+++ b/pidecola_back/settings.py
@@ -38,7 +38,7 @@ SECRET_KEY = 'django-insecure-to81=t+gc4eqjqpeh$(+y!h(0s9s28nc_y*)a2*4(lsav9wbx-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['host.docker.internal', '127.0.0.1', 'localhost']
 
 
 # Application definition

--- a/pidecola_back/urls.py
+++ b/pidecola_back/urls.py
@@ -35,7 +35,7 @@ main_router.registry.extend(rides_router.registry)
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('auth/login/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('auth/register/', RegisterView.as_view(), name='auth_register'),
+    path('auth/register/', RegisterView.as_view({'post': 'create'}), name='auth_register'),
     path('auth/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('auth/logout/', TokenBlacklistView.as_view(), name='token_blacklist'),
     path('', include(main_router.urls)),

--- a/users/models.py
+++ b/users/models.py
@@ -15,11 +15,10 @@ class User(AbstractUser):
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
-    role = models.CharField(max_length=16, choices=ROLES)
+    role = models.CharField(max_length=16, choices=ROLES, default=USER)
     rating = models.FloatField(default=5.0)
     rating_count = models.IntegerField(default=0)
-    phone_number_area_code = models.CharField(max_length=4, default='')
-    phone_number = models.CharField(max_length=7, default='')
+    phone_number = models.CharField(max_length=12, default='')
 
     def __str__(self):
         return self.username

--- a/users/views.py
+++ b/users/views.py
@@ -1,21 +1,19 @@
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 
 from users.models import User, Vehicle
 from users.serializers import UserSerializer, VehicleSerializer
-from custom import CustomPermission
 
 # Create your views here.
 class UserViewSet(viewsets.ModelViewSet):
-
+    permission_classes = [IsAuthenticated]
     serializer_class = UserSerializer
     queryset = User.objects.all()
-    permission_classes = [CustomPermission]
 
 
 class VehicleViewSet(viewsets.ModelViewSet):
-
+    permission_classes = [IsAuthenticated]
     serializer_class = VehicleSerializer
     queryset = Vehicle.objects.all()
-    permission_classes = [CustomPermission]


### PR DESCRIPTION
This Pull Request changes user registration management through `/auth/register/` endpoint:

- User is saved using its username, email, first name, last name, phone number and password.
- After new user was saved successfully, sends back both refresh and access tokens.

Also, user's model and view controllers are changed:

- Phone number is a single attribute and no two: phone number code and phone number.
- Views permissions are now `IsAuthenticated`. So any user with a valid token can access to `/accounts/*` endpoints.